### PR TITLE
Added states and mappings sections

### DIFF
--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -46,40 +46,47 @@
   }
 
   var mappings = {
-    default: {
-      common: {
-        triggerdown: 'testlog'
-      },
-      'vive-controls': {
-        gripdown: 'changeTask'
-      },
-      'oculus-touch-controls': {
-        abuttondown: 'changeTask'
-      },
-      'windows-motion-controls': {
-        gripdown: 'changeTask'
-      },
-      keyboard: {
-        't_up': 'testlog',
-        'c_up': 'changeTask'
-      }
+    actions: {
+      changeTask: { label: 'Change task' },
+      testlog: { label: 'Test Log' },
+      testlog_task1: { label: 'Test Log Task 1' }
     },
-    task1: {
-      'vive-controls': {
-        triggerdown: 'testlog_task1',
-        gripdown: 'changeTask'
+    mappings: {
+      default: {
+        common: {
+          triggerdown: 'testlog'
+        },
+        'vive-controls': {
+          gripdown: 'changeTask'
+        },
+        'oculus-touch-controls': {
+          abuttondown: 'changeTask'
+        },
+        'windows-motion-controls': {
+          gripdown: 'changeTask'
+        },
+        keyboard: {
+          't_up': 'testlog',
+          'c_up': 'changeTask'
+        }
       },
-      'oculus-touch-controls': {
-        triggerdown: 'testlog_task1',
-        abuttondown: 'changeTask'
-      },
-      'windows-motion-controls': {
-        triggerdown: 'testlog_task1',
-        gripdown: 'changeTask'
-      },
-      keyboard: {
-        'y_up': 'testlog_task1',
-        'c_up': 'changeTask'
+      task1: {
+        'vive-controls': {
+          triggerdown: 'testlog_task1',
+          gripdown: 'changeTask'
+        },
+        'oculus-touch-controls': {
+          triggerdown: 'testlog_task1',
+          abuttondown: 'changeTask'
+        },
+        'windows-motion-controls': {
+          triggerdown: 'testlog_task1',
+          gripdown: 'changeTask'
+        },
+        keyboard: {
+          'y_up': 'testlog_task1',
+          'c_up': 'changeTask'
+        }
       }
     }
   };
@@ -102,20 +109,26 @@
 
   function init()
   {
-    scene.addEventListener('changeTask', function(evt) {
-      AFRAME.currentMapping = AFRAME.currentMapping === 'default' ? 'task1' : 'default';
-      mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentMapping});
-      drawText('Changing task. ' + AFRAME.currentMapping);
-    });
+    function logEvent(evt) {
+      var text = AFRAME.inputMappings.actions[evt.type].label;
+      console.log(text);
+      drawText(text);
+    }
 
     mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentMapping});
 
+    scene.addEventListener('changeTask', function(evt) {
+      AFRAME.currentMapping = AFRAME.currentMapping === 'default' ? 'task1' : 'default';
+      mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentMapping});
+      logEvent(evt);
+    });
+
     scene.addEventListener('testlog_task1', function(evt) {
-      drawText('TestLog TASK1!');
+      logEvent(evt);
     });
 
     scene.addEventListener('testlog', function(evt) {
-      drawText('TestLog event!');
+      logEvent(evt);
     });
   }
   </script>

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -115,11 +115,11 @@
       drawText(text);
     }
 
-    mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentMapping});
+    mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentInputMapping});
 
     scene.addEventListener('changeTask', function(evt) {
-      AFRAME.currentMapping = AFRAME.currentMapping === 'default' ? 'task1' : 'default';
-      mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentMapping});
+      AFRAME.currentInputMapping = AFRAME.currentInputMapping === 'default' ? 'task1' : 'default';
+      mappingText.setAttribute('text', {value: 'Current mapping: ' + AFRAME.currentInputMapping});
       logEvent(evt);
     });
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ if (typeof AFRAME === 'undefined') {
 AFRAME.currentMapping = 'default';
 AFRAME.inputMappings = {};
 
-var inputMappings = AFRAME.inputMappings;
-
 AFRAME.registerSystem('input-mapping', {
   mappings: {},
   mappingsPerControllers: {},
@@ -67,7 +65,7 @@ AFRAME.registerSystem('input-mapping', {
   updateControllersListeners: function (controllerObj) {
     this.removeControllerListeners(controllerObj);
 
-    if (!inputMappings) {
+    if (!AFRAME.inputMappings.mappings) {
       console.warn('controller-mapping: No mappings defined');
       return;
     }
@@ -75,8 +73,8 @@ AFRAME.registerSystem('input-mapping', {
     var mappingsPerController = this.mappingsPerControllers[controllerObj.name] = {};
 
     // Create the listener for each event
-    for (var mappingName in inputMappings) {
-      var mapping = inputMappings[mappingName];
+    for (var mappingName in AFRAME.inputMappings.mappings) {
+      var mapping = AFRAME.inputMappings.mappings[mappingName];
 
       var commonMappings = mapping.common;
       if (commonMappings) {
@@ -106,7 +104,7 @@ AFRAME.registerSystem('input-mapping', {
   },
 
   keyboardHandler: function (event) {
-    var mappings = inputMappings[AFRAME.currentMapping];
+    var mappings = AFRAME.inputMappings.mappings[AFRAME.currentMapping];
 
     if (mappings && mappings.keyboard) {
       mappings = mappings.keyboard;
@@ -139,26 +137,33 @@ AFRAME.registerSystem('input-mapping', {
   }
 });
 
-AFRAME.registerInputMappings = function (mappings, override) {
-  if (override || Object.keys(inputMappings).length === 0) {
-    inputMappings = mappings;
+AFRAME.registerInputMappings = function (data, override) {
+  if (override || Object.keys(AFRAME.inputMappings).length === 0) {
+    AFRAME.inputMappings = data;
   } else {
-    for (var mappingName in mappings) {
-      var mapping = mappings[mappingName];
-      if (!inputMappings[mappingName]) {
-        inputMappings[mappingName] = mapping;
+    // @todo Merge actions instead of replacing them with the newest
+    if (data.actions) {
+      AFRAME.inputMappings.actions = data.actions;
+    }
+
+    // Merge mappings
+    var mappings = data.mappings;
+    for (var mappingName in data.mappings) {
+      var mapping = data.mappings[mappingName];
+      if (!AFRAME.inputMappings.mappings[mappingName]) {
+        AFRAME.inputMappings.mappings[mappingName] = mapping;
         continue;
       }
 
       for (var controllerName in mapping) {
         var controllerMapping = mapping[controllerName];
-        if (!inputMappings[mappingName][controllerName]) {
-          inputMappings[mappingName][controllerName] = controllerMapping;
+        if (!AFRAME.inputMappings.mappings[mappingName][controllerName]) {
+          AFRAME.inputMappings.mappings[mappingName][controllerName] = controllerMapping;
           continue;
         }
 
         for (var eventName in controllerMapping) {
-          inputMappings[mappingName][controllerName][eventName] = controllerMapping[eventName];
+          AFRAME.inputMappings.mappings[mappingName][controllerName][eventName] = controllerMapping[eventName];
         }
       }
     }
@@ -167,4 +172,5 @@ AFRAME.registerInputMappings = function (mappings, override) {
   for (var i = 0; i < AFRAME.scenes.length; i++) {
     AFRAME.scenes[i].emit('inputmappingregistered');
   }
+  console.log(AFRAME.inputMappings);
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ if (typeof AFRAME === 'undefined') {
   throw new Error('Component attempted to register before AFRAME was available.');
 }
 
-AFRAME.currentMapping = 'default';
+AFRAME.currentInputMapping = 'default';
 AFRAME.inputMappings = {};
 
 AFRAME.registerSystem('input-mapping', {
@@ -92,7 +92,7 @@ AFRAME.registerSystem('input-mapping', {
     for (var eventName in mappingsPerController) {
       var handler = function (event) {
         var mapping = mappingsPerController[event.type];
-        var mappedEvent = mapping[AFRAME.currentMapping] ? mapping[AFRAME.currentMapping] : mapping.default;
+        var mappedEvent = mapping[AFRAME.currentInputMapping] ? mapping[AFRAME.currentInputMapping] : mapping.default;
         if (mappedEvent) {
           event.detail.target.emit(mappedEvent, event.detail);
         }
@@ -104,7 +104,7 @@ AFRAME.registerSystem('input-mapping', {
   },
 
   keyboardHandler: function (event) {
-    var mappings = AFRAME.inputMappings.mappings[AFRAME.currentMapping];
+    var mappings = AFRAME.inputMappings.mappings[AFRAME.currentInputMapping];
 
     if (mappings && mappings.keyboard) {
       mappings = mappings.keyboard;
@@ -172,5 +172,4 @@ AFRAME.registerInputMappings = function (data, override) {
   for (var i = 0; i < AFRAME.scenes.length; i++) {
     AFRAME.scenes[i].emit('inputmappingregistered');
   }
-  console.log(AFRAME.inputMappings);
 };


### PR DESCRIPTION
Added the most conservatives changes from https://github.com/fernandojsg/aframe-input-mapping-component/issues/3

the structure now is:
```js
{
    actions: {
      changeTask: { label: 'Change task' },
      testlog: { label: 'Test Log' },
      testlog_task1: { label: 'Test Log Task 1' }
    },
    mappings: {
      default: {
        common: {
          triggerdown: 'testlog'
        },
        'vive-controls': {
          gripdown: 'changeTask'
        },
        'oculus-touch-controls': {
          abuttondown: 'changeTask'
        },
        'windows-motion-controls': {
          gripdown: 'changeTask'
        },
        keyboard: {
          't_up': 'testlog',
          'c_up': 'changeTask'
        }
      },
      task1: {
        'vive-controls': {
          triggerdown: 'testlog_task1',
          gripdown: 'changeTask'
        },
        'oculus-touch-controls': {
          triggerdown: 'testlog_task1',
          abuttondown: 'changeTask'
        },
        'windows-motion-controls': {
          triggerdown: 'testlog_task1',
          gripdown: 'changeTask'
        },
        keyboard: {
          'y_up': 'testlog_task1',
          'c_up': 'changeTask'
        }
      }
    }
  };
```

I don't have an strong opinion about the naming on `states` or `mapping`

/cc @netpro2k @dmarcos
