### PR TITLE
Fixes #14 Remove actions from mappings

### DIFF
--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -14,8 +14,15 @@
         <img id="skyTexture" src="https://cdn.aframe.io/a-painter/images/sky.jpg">
       </a-assets>
 
-      <a-entity id="leftHand" vive-controls="hand: left"></a-entity>
-      <a-entity id="rightHand" vive-controls="hand: right"></a-entity>
+      <a-entity id="leftHand" oculus-touch-controls="hand: left"
+          gearvr-controls="hand: left"
+          daydream-controls="hand: left" vive-controls="hand: left">
+      </a-entity>
+      <a-entity id="rightHand" oculus-touch-controls="hand: right"
+          gearvr-controls="hand: right"
+          daydream-controls="hand: right"
+          vive-controls="hand: right">
+      </a-entity>
 
       <a-plane src="#groundTexture" rotation="-90 0 0" height="100" width="100"></a-plane>
       <a-light type="ambient" color="#445451"></a-light>
@@ -43,54 +50,67 @@
     scene.addEventListener('loaded', init);
   }
 
-  var mappings = {
-    actions: {
+  // To be exposed by the application
+  var inputActions = {
+    default: {
       changeTask: { label: 'Change task' },
-      testlog: { label: 'Test Log' },
-      testlog_task1: { label: 'Test Log Task 1' }
+      testlog: { label: 'Test Log' }
     },
-    mappings: {
-      default: {
-        common: {
-          triggerdown: 'testlog'
-        },
-        'vive-controls': {
-          gripdown: 'changeTask',
-          trackpaddown: 'testlog'
-        },
-        'oculus-touch-controls': {
-          abuttondown: 'changeTask'
-        },
-        'windows-motion-controls': {
-          gripdown: 'changeTask'
-        },
-        keyboard: {
-          't_up': 'testlog',
-          'c_up': 'changeTask'
-        }
+    task1: {
+      changeTask: { label: 'Change task' },
+      testlog_task1: { label: 'Test Log Task 1' }
+    }
+  }
+
+  AFRAME.registerInputActions(inputActions);
+
+  // Could be defined by default by the app or the user, custom UI, external request, etc.
+  var mappings = {
+    default: {
+      common: {
+        triggerdown: 'testlog'
       },
-      task1: {
-        'vive-controls': {
-          triggerdown: 'testlog_task1',
-          gripdown: 'changeTask'
-        },
-        'oculus-touch-controls': {
-          triggerdown: 'testlog_task1',
-          abuttondown: 'changeTask'
-        },
-        'windows-motion-controls': {
-          triggerdown: 'testlog_task1',
-          gripdown: 'changeTask'
-        },
-        keyboard: {
-          'y_up': 'testlog_task1',
-          'c_up': 'changeTask'
-        }
+      'vive-controls': {
+        gripdown: 'changeTask',
+        trackpaddown: 'testlog2'
+      },
+      'daydream-controls': {
+        trackpaddown: 'testlog'
+      },
+      'oculus-touch-controls': {
+        abuttondown: 'changeTask'
+      },
+      'windows-motion-controls': {
+        gripdown: 'changeTask'
+      },
+      keyboard: {
+        't_up': 'testlog',
+        'c_up': 'changeTask'
+      }
+    },
+    task1: {
+      'vive-controls': {
+        triggerdown: 'testlog_task1',
+        gripdown: 'changeTask'
+      },
+      'daydream-controls': {
+        trackpaddown: 'testlog_task1'
+      },
+      'oculus-touch-controls': {
+        triggerdown: 'testlog_task1',
+        abuttondown: 'changeTask'
+      },
+      'windows-motion-controls': {
+        triggerdown: 'testlog_task1',
+        gripdown: 'changeTask'
+      },
+      keyboard: {
+        'y_up': 'testlog_task1',
+        'c_up': 'changeTask'
       }
     }
   };
 
-  // AFRAME.DEFAULT_INPUT_MAPPINGS = mappings;
   AFRAME.registerInputMappings(mappings);
 
   var buttonsText = document.getElementById('textbuttons');
@@ -108,7 +128,7 @@
   function init()
   {
     function logEvent(evt) {
-      var text = AFRAME.inputMappings.actions[evt.type].label;
+      var text = AFRAME.inputActions[AFRAME.currentInputMapping][evt.type].label;
       console.log(text);
       drawText(text);
     }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ if (typeof AFRAME === 'undefined') {
 
 AFRAME.currentInputMapping = 'default';
 AFRAME.inputMappings = {};
+AFRAME.inputActions = {};
 
 AFRAME.registerSystem('input-mapping', {
   mappings: {},
@@ -91,16 +92,16 @@ AFRAME.registerSystem('input-mapping', {
   updateControllersListeners: function (controllerObj) {
     this.removeControllerListeners(controllerObj);
 
-    if (!AFRAME.inputMappings.mappings) {
-      console.warn('controller-mapping: No mappings defined');
+    if (!AFRAME.inputMappings) {
+      console.warn('input-mapping: No mappings defined');
       return;
     }
 
     var mappingsPerController = this.mappingsPerControllers[controllerObj.name] = {};
 
     // Create the listener for each event
-    for (var mappingName in AFRAME.inputMappings.mappings) {
-      var mapping = AFRAME.inputMappings.mappings[mappingName];
+    for (var mappingName in AFRAME.inputMappings) {
+      var mapping = AFRAME.inputMappings[mappingName];
 
       var commonMappings = mapping.common;
       if (commonMappings) {
@@ -111,7 +112,7 @@ AFRAME.registerSystem('input-mapping', {
       if (controllerMappings) {
         this.updateMappingsPerController(controllerMappings, mappingsPerController, mappingName);
       } else {
-        console.warn('controller-mapping: No mappings defined for controller type: ', controllerObj.name);
+        console.warn('input-mapping: No mappings defined for controller type: ', controllerObj.name);
       }
     }
 
@@ -130,7 +131,7 @@ AFRAME.registerSystem('input-mapping', {
   },
 
   keyboardHandler: function (event) {
-    var mappings = AFRAME.inputMappings.mappings[AFRAME.currentInputMapping];
+    var mappings = AFRAME.inputMappings[AFRAME.currentInputMapping];
 
     if (mappings && mappings.keyboard) {
       mappings = mappings.keyboard;
@@ -163,32 +164,31 @@ AFRAME.registerSystem('input-mapping', {
   }
 });
 
+AFRAME.registerInputActions = function (inputActions) {
+  AFRAME.inputActions = inputActions;
+};
+
 AFRAME.registerInputMappings = function (data, override) {
   if (override || Object.keys(AFRAME.inputMappings).length === 0) {
     AFRAME.inputMappings = data;
   } else {
-    // @todo Merge actions instead of replacing them with the newest
-    if (data.actions) {
-      AFRAME.inputMappings.actions = data.actions;
-    }
-
     // Merge mappings
-    for (var mappingName in data.mappings) {
-      var mapping = data.mappings[mappingName];
-      if (!AFRAME.inputMappings.mappings[mappingName]) {
-        AFRAME.inputMappings.mappings[mappingName] = mapping;
+    for (var mappingName in data) {
+      var mapping = data[mappingName];
+      if (!AFRAME.inputMappings[mappingName]) {
+        AFRAME.inputMappings[mappingName] = mapping;
         continue;
       }
 
       for (var controllerName in mapping) {
         var controllerMapping = mapping[controllerName];
-        if (!AFRAME.inputMappings.mappings[mappingName][controllerName]) {
-          AFRAME.inputMappings.mappings[mappingName][controllerName] = controllerMapping;
+        if (!AFRAME.inputMappings[mappingName][controllerName]) {
+          AFRAME.inputMappings[mappingName][controllerName] = controllerMapping;
           continue;
         }
 
         for (var eventName in controllerMapping) {
-          AFRAME.inputMappings.mappings[mappingName][controllerName][eventName] = controllerMapping[eventName];
+          AFRAME.inputMappings[mappingName][controllerName][eventName] = controllerMapping[eventName];
         }
       }
     }


### PR DESCRIPTION
Proposal:
```javascript
  // To be exposed by the application
  var inputActions = {
    default: {
      changeTask: { label: 'Change task' },
      testlog: { label: 'Test Log' }
    },
    task1: {
      changeTask: { label: 'Change task' },
      testlog_task1: { label: 'Test Log Task 1' }
    }
  }

  AFRAME.registerInputActions(inputActions);

  // Could be defined by default by the app or the user, custom UI, external request, etc.
  var mappings = {
    default: {
      common: {
        triggerdown: 'testlog'
      },
      'vive-controls': {
        gripdown: 'changeTask',
        trackpaddown: 'testlog2'
      },
      'daydream-controls': {
        trackpaddown: 'testlog'
      },
      'oculus-touch-controls': {
        abuttondown: 'changeTask'
      },
      'windows-motion-controls': {
        gripdown: 'changeTask'
      },
      keyboard: {
        't_up': 'testlog',
        'c_up': 'changeTask'
      }
    },
    task1: {
      'vive-controls': {
        triggerdown: 'testlog_task1',
        gripdown: 'changeTask'
      },
      'daydream-controls': {
        trackpaddown: 'testlog_task1'
      },
      'oculus-touch-controls': {
        triggerdown: 'testlog_task1',
        abuttondown: 'changeTask'
      },
      'windows-motion-controls': {
        triggerdown: 'testlog_task1',
        gripdown: 'changeTask'
      },
      keyboard: {
        'y_up': 'testlog_task1',
        'c_up': 'changeTask'
      }
    }
  };

  AFRAME.registerInputMappings(mappings);
```